### PR TITLE
Allow loading of zenodo records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ jspm_packages
 
 # IDE settings
 .vscode
+.eslintrc.json

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ Node.js implementation to load compendia from third party repositories and resou
 
 Currently, it implements the endpoint `/api/v2/compendium`.
 
+## Supported repositories
+
+- Sciebo (https://sciebo.de)
+- Zenodo or Zenodo Sandbox (https://zenodo.org or https://sandbox.zenodo.org)
+
 ## Requirements
 
 Requirements:

--- a/config/config.js
+++ b/config/config.js
@@ -127,8 +127,9 @@ c.webdav.allowedHosts = ['sciebo'];
 c.webdav.urlString = 'public.php/webdav'; //end of webdav pubilc webdav url
 //c.webdav.urlString = 'nextcloud/public.php/dav'; //nextcloud public webdav url
 
-//allowed hosts for zenodo load
+//zenodo configuration
 c.zenodo.url = 'https://zenodo.org/';
 c.zenodo.sandbox_url = 'https://sandbox.zenodo.org/';
+c.zenodo.token = env.ZENODO_TOKEN;
 
 module.exports = c;

--- a/config/config.js
+++ b/config/config.js
@@ -130,6 +130,7 @@ c.webdav.urlString = 'public.php/webdav'; //end of webdav pubilc webdav url
 //zenodo configuration
 c.zenodo.url = 'https://zenodo.org/';
 c.zenodo.sandbox_url = 'https://sandbox.zenodo.org/';
+c.zenodo.fallback_host = 'sandbox.zenodo.org';
 c.zenodo.token = env.ZENODO_TOKEN;
 
 module.exports = c;

--- a/config/config.js
+++ b/config/config.js
@@ -128,9 +128,8 @@ c.webdav.urlString = 'public.php/webdav'; //end of webdav pubilc webdav url
 //c.webdav.urlString = 'nextcloud/public.php/dav'; //nextcloud public webdav url
 
 //zenodo configuration
-c.zenodo.url = 'https://zenodo.org/';
-c.zenodo.sandbox_url = 'https://sandbox.zenodo.org/';
-c.zenodo.fallback_host = 'sandbox.zenodo.org';
+c.zenodo.url = 'https://sandbox.zenodo.org/';
+c.zenodo.host = 'sandbox.zenodo.org';
 c.zenodo.token = env.ZENODO_TOKEN;
 
 module.exports = c;

--- a/config/config.js
+++ b/config/config.js
@@ -128,8 +128,12 @@ c.webdav.urlString = 'public.php/webdav'; //end of webdav pubilc webdav url
 //c.webdav.urlString = 'nextcloud/public.php/dav'; //nextcloud public webdav url
 
 //zenodo configuration
-c.zenodo.url = 'https://sandbox.zenodo.org/';
-c.zenodo.host = 'sandbox.zenodo.org';
-c.zenodo.token = env.ZENODO_TOKEN;
+// default URL and host that is used to download files if the URL itself is not specified in the request (e.g. via DOI or zenodo_record_id parameter)
+c.zenodo.default_url = 'https://sandbox.zenodo.org/';
+c.zenodo.default_host = 'sandbox.zenodo.org';
+
+//base urls for zenodo and zenodo sandbox
+c.zenodo.zenodo_sandbox_url = 'https://sandbox.zenodo.org/';
+c.zenodo.zenodo_url = 'https://zenodo.org/';
 
 module.exports = c;

--- a/config/config.js
+++ b/config/config.js
@@ -20,6 +20,7 @@ c.net = {};
 c.mongo = {};
 c.fs = {};
 c.webdav = {};
+c.zenodo = {};
 var env = process.env;
 
 // Information about loader
@@ -125,5 +126,9 @@ c.bagtainer.metaextract.failOnNoMetadata = false;
 c.webdav.allowedHosts = ['sciebo'];
 c.webdav.urlString = 'public.php/webdav'; //end of webdav pubilc webdav url
 //c.webdav.urlString = 'nextcloud/public.php/dav'; //nextcloud public webdav url
+
+//allowed hosts for zenodo load
+c.zenodo.url = 'https://zenodo.org/';
+c.zenodo.sandbox_url = 'https://sandbox.zenodo.org/';
 
 module.exports = c;

--- a/controllers/download.js
+++ b/controllers/download.js
@@ -115,7 +115,7 @@ function prepareScieboLoad(req, res) {
   }
 
   var loader = new Loader(req, res);
-  loader.load((id, err) => {
+  loader.loadOwncloud((id, err) => {
     if (err) {
       debug('Error during public share load: %s', err.message);
     } else {

--- a/controllers/download.js
+++ b/controllers/download.js
@@ -38,6 +38,11 @@ exports.create = (req, res) => {
     return;
   }
 
+  // check for ZENODO url -> start zenodo loader
+  if(req.body.zenodo_url !== null){
+    //start zenodo loader
+  }
+
   // validate share_url
   if(!validator.isURL(req.body.share_url)) {
     debug('Invalid share_url:', req.body.share_url);

--- a/controllers/download.js
+++ b/controllers/download.js
@@ -59,7 +59,7 @@ exports.create = (req, res) => {
       return;
     }
 
-    req.params.zenodoHost = c.zenodo.fallback_host;
+    req.params.zenodoHost = c.zenodo.host;
     prepareZenodoLoad(req, res);
     return;
   }
@@ -72,7 +72,7 @@ exports.create = (req, res) => {
       return;
     }
     req.params.zenodoID = req.body.zenodo_record_id;
-    req.params.zenodoHost = c.zenodo.fallback_host;
+    req.params.zenodoHost = c.zenodo.host;
     prepareZenodoLoad(req, res);
     return;
   }
@@ -98,14 +98,12 @@ exports.create = (req, res) => {
       // get zenodo record ID from Zenodo URL, e.g. https://sandbox.zenodo.org/record/59917
       let zenodoPaths = parsedURL.path.split('/');
       let zenodoID = zenodoPaths[zenodoPaths.length - 1];
-      req.params.zenodoHost = parsedURL.host;
       req.params.zenodoID = zenodoID;
       prepareZenodoLoad(req, res);
       break;
     case 'doi':
       // get zenodoID from DOI URL, e.g. https://doi.org/10.5281/zenodo.268443
       req.params.zenodoID = parsedURL.path.split('zenodo.')[1];
-      req.params.zenodoHost = c.zenodo.fallback_host;
       prepareZenodoLoad(req, res);
       break;
     default:
@@ -149,20 +147,6 @@ function prepareScieboLoad(req, res) {
 function prepareZenodoLoad(req, res) {
   this.req = req;
   this.res = res;
-
-  //validate host (must be zenodo or sandbox.zenodo)
-  switch (req.params.zenodoHost) {
-    case 'sandbox.zenodo.org':
-      req.params.baseURL = c.zenodo.sandbox_url;
-      break;
-    case c.zenodo.fallback_host:
-      req.params.baseURL = c.zenodo.url;
-      break;
-    default:
-      debug('Invalid hostname:', req.params.zenodoHost);
-      res.status(403).send('{"error":"host is not allowed"}');
-      return;
-  }
 
   // validate zenodoID
   if (!validator.isNumeric(String(req.params.zenodoID))){

--- a/controllers/download.js
+++ b/controllers/download.js
@@ -63,8 +63,22 @@ exports.create = (req, res) => {
     let zenodoID = zenodoPaths[zenodoPaths.length - 1];
     req.body.zenodo_id = zenodoID;
 
+    //validate host (must be zenodo or sandbox.zenodo)
+    switch (parsedURL.host) {
+      case 'sandbox.zenodo.org':
+        req.body.base_url = c.zenodo.sandbox_url;
+        break;
+      case 'zenodo.org':
+        req.body.base_url = c.zenodo.url;
+        break;
+      default:
+        debug('Invalid hostname:', parsedURL.host);
+        res.status(404).send('{"error":"hostname must be zenodo or sandbox.zenodo"}');
+        return;
+    }
+
     // validate zenodoID
-    if (!validator.isNumeric(zenodoID)){
+    if (!validator.isNumeric(String(zenodoID))){
       debug('Invalid zenodoID:', zenodoID);
       res.status(404).send('{"error":"zenodo ID is not a number"}');
       return;
@@ -76,7 +90,7 @@ exports.create = (req, res) => {
         req.body.content_type, req.user.id);
 
       var loader = new Loader(req, res);
-      loader.load((id, err) => {
+      loader.loadZenodo((id, err) => {
         if (err) {
           debug('Error during public share load: %s', err.message);
         } else {
@@ -87,7 +101,7 @@ exports.create = (req, res) => {
       res.status(500).send('Provided content_type not yet implemented, only "compendium_v1" is supported.');
       debug('Provided content_type "%s" not implemented', req.body.content_type);
     } 
-
+    return;
   }
 
   // validate share_url

--- a/controllers/download.js
+++ b/controllers/download.js
@@ -54,7 +54,7 @@ exports.create = (req, res) => {
 
   // get top-level hostname from share_url
   let parsedURL = url.parse(req.body.share_url);
-  let hostname = validURL.hostname.split('.');
+  let hostname = parsedURL.hostname.split('.');
   hostname = hostname[hostname.length - 2];
   req.hostname = hostname;
 

--- a/controllers/download.js
+++ b/controllers/download.js
@@ -55,7 +55,7 @@ exports.create = (req, res) => {
       req.params.zenodoID = req.body.doi.split('zenodo.')[1];
     } else {
       debug('Invalid doi:', req.body.doi);
-      res.status(404).send('{"error":"DOI is invalid"}');
+      res.status(422).send('{"error":"DOI is invalid"}');
       return;
     }
 
@@ -68,7 +68,7 @@ exports.create = (req, res) => {
   if (typeof req.body.zenodo_record_id !== 'undefined') {
     if (isNaN(req.body.zenodo_record_id)) {
       debug('Invalid zenodo_record_id:', req.body.zenodo_record_id);
-      res.status(404).send('{"error":"zenodo_record_id is invalid"}');
+      res.status(422).send('{"error":"zenodo_record_id is invalid"}');
       return;
     }
     req.params.zenodoID = req.body.zenodo_record_id;
@@ -80,7 +80,7 @@ exports.create = (req, res) => {
   // validate share_url
   if(!validator.isURL(req.body.share_url)) {
       debug('Invalid share_url:', req.body.share_url);
-      res.status(404).send('{"error":"public share URL is invalid"}');
+      res.status(422).send('{"error":"public share URL is invalid"}');
       return;
   }
 
@@ -151,7 +151,7 @@ function prepareZenodoLoad(req, res) {
   // validate zenodoID
   if (!validator.isNumeric(String(req.params.zenodoID))){
     debug('Invalid zenodoID:', req.params.zenodoID);
-    res.status(404).send('{"error":"zenodo ID is not a number"}');
+    res.status(422).send('{"error":"zenodo ID is not a number"}');
     return;
   }
 

--- a/controllers/download.js
+++ b/controllers/download.js
@@ -38,8 +38,10 @@ exports.create = (req, res) => {
     return;
   }
 
+  //TODO here: write function for webdav and zenodo + cleanup
+
   // check for ZENODO url -> start zenodo loader
-  if(req.body.zenodo_url !== null){
+  if(req.body.zenodo_url !== undefined){
     //start zenodo loader
 
     // validate zenodo_url

--- a/controllers/download.js
+++ b/controllers/download.js
@@ -47,7 +47,7 @@ exports.create = (req, res) => {
   }
 
   // if the DOI parameter exists, extract the zenodo record ID from it
-  if (typeof req.body.doi !== undefined) {
+  if (typeof req.body.doi !== 'undefined') {
     //regex for a DOI (e.g. "10.5281/zenodo.268443")
     let doiRegex = new RegExp(/^\d+\.\d+\/zenodo\.\d+$/);
 
@@ -59,20 +59,20 @@ exports.create = (req, res) => {
       return;
     }
 
-    req.params.zenodoHost = 'zenodo.org';
+    req.params.zenodoHost = c.zenodo.fallback_host;
     prepareZenodoLoad(req, res);
     return;
   }
 
   // if the zenodo_record_id parameter exists, start the zenodo loader with it
-  if (typeof req.body.zenodo_record_id !== undefined) {
+  if (typeof req.body.zenodo_record_id !== 'undefined') {
     if (isNaN(req.body.zenodo_record_id)) {
       debug('Invalid zenodo_record_id:', req.body.zenodo_record_id);
-      res.status(404).send('{"error":"public share URL is invalid"}');
+      res.status(404).send('{"error":"zenodo_record_id is invalid"}');
       return;
     }
     req.params.zenodoID = req.body.zenodo_record_id;
-    req.params.zenodoHost = 'zenodo.org';
+    req.params.zenodoHost = c.zenodo.fallback_host;
     prepareZenodoLoad(req, res);
     return;
   }
@@ -105,6 +105,7 @@ exports.create = (req, res) => {
     case 'doi':
       // get zenodoID from DOI URL, e.g. https://doi.org/10.5281/zenodo.268443
       req.params.zenodoID = parsedURL.path.split('zenodo.')[1];
+      req.params.zenodoHost = c.zenodo.fallback_host;
       prepareZenodoLoad(req, res);
       break;
     default:
@@ -154,7 +155,7 @@ function prepareZenodoLoad(req, res) {
     case 'sandbox.zenodo.org':
       req.params.baseURL = c.zenodo.sandbox_url;
       break;
-    case 'zenodo.org':
+    case c.zenodo.fallback_host:
       req.params.baseURL = c.zenodo.url;
       break;
     default:

--- a/controllers/download.js
+++ b/controllers/download.js
@@ -73,7 +73,7 @@ exports.create = (req, res) => {
         break;
       default:
         debug('Invalid hostname:', parsedURL.host);
-        res.status(404).send('{"error":"hostname must be zenodo or sandbox.zenodo"}');
+        res.status(403).send('{"error":"host is not allowed"}');
         return;
     }
 

--- a/lib/loader-steps.js
+++ b/lib/loader-steps.js
@@ -27,8 +27,7 @@ const fs = require('fs');
 const url = require('url');
 const createClient = require('webdav');
 const https = require('https');
-const scrape = require('html-metadata');
-
+const htmlparser = require('htmlparser2');
 
 if (config.bagtainer.scan.enable) {
     debug('Using clamscan with configuration %s', JSON.stringify(clam.settings));
@@ -90,25 +89,51 @@ function publicShareLoad(passon) {
 }
 
 /**
- * Loads filename(s) from the zenodo record by reading the HTML headers
+ * Loads filename(s) from the zenodo record by parsing the HTML document
  * @param {string} passon.zenodoID - The zenodo record id.
  * @param {string} passon.baseURL - The zenodo URL without a path (https://zenodo.org or https://sandbox.zenodo.org).
  */
 function checkZenodoContents(passon){
     return new Promise((fulfill, reject) => {
- 
-        var url = 'https://sandbox.zenodo.org/record/18401';
-        
-        scrape(url)
-        .then(function(metadata){
-            debug(metadata);
-            fulfill(passon);
-        })
-        .catch(function (err) {
-            debug(err);
-            err.status = 404;
-            err.message = 'Could not read zenodo record contents';
-            reject(err);
+        let requestURL = passon.baseURL + 'record/' + passon.zenodoID;
+
+        https.get(requestURL, (res) => {
+            debug('Fetched zenodo contents, statusCode:', res.statusCode);
+
+            res.on('data', (d) => {
+                debug('Successfully loaded zenodo html document!');
+
+                let zenodoLinks = [];
+                //parse the html document and extract links such as "<link rel="alternate" type="application/zip" href="https://sandbox.zenodo.org/record/69114/files/metatainer.zip">"
+                var parser = new htmlparser.Parser({
+                onopentag: function(name, attribs){
+                    if(name === 'link' && attribs.rel === 'alternate' && attribs.type === 'application/zip'){
+                        //save links to files in zenodoLinks
+                        zenodoLinks.push(attribs.href);
+                    }
+                }
+                }, {decodeEntities: true});
+                parser.write(d.toString());
+                parser.end();
+
+                if (zenodoLinks.length === 0) { //If the parser did not find any zip files in the HTML document
+                    debug('No files found in zenodo deposit.');
+                    let err = new Error('No files found in zenodo deposit.');
+                    err.status = 404;
+                    reject(err);                    
+                }
+
+                // Handle only the first zip file (for now)
+                passon.zenodoLink = zenodoLinks[0];
+                debug('Parsing zenodo contents completed');
+                fulfill(passon);
+            });
+
+        }).on('error', (e) => {
+            debug('Loading file list failed, error: %s', e);
+            e.status = 404;
+            e.message = 'Loading file list failed';
+            reject(e); 
         });
     });
 }
@@ -172,13 +197,25 @@ function checkZenodoContentsViaAPI(passon){
 /**
  * Loads a single file from zenodo.org or sandbox.zenodo.org
  * @param {string} passon.filename - Name of the file in the zenodo deposit.
+ * @param {string} passon.zenodoLink - Download link of the first zip file in the zenodo record
  * @param {string} passon.zenodoID - The zenodo record id.
  * @param {string} passon.baseURL - The zenodo URL without a path (https://zenodo.org or https://sandbox.zenodo.org).
  */
 function zenodoLoad(passon) {
     return new Promise((fulfill, reject) => {
         debug('Loading files from Zenodo');
-        let downloadURL = passon.baseURL + path.join('record/', passon.zenodoID, '/files/', passon.filename);
+        let downloadURL;
+        if (passon.zenodoLink !== undefined) {
+            downloadURL = passon.zenodoLink;
+        } else if (passon.filename !== undefined) {
+            downloadURL = passon.baseURL + path.join('record/', passon.zenodoID, '/files/', passon.filename);
+        } else {
+            debug('No download link or filename provided');
+            let err = new Error('No download link or filename provided');
+            err.status = 404;
+            reject(err);
+        }
+
         var zipPath = path.join(config.fs.incoming, passon.id);
         var cmd = 'wget -q -O ' + zipPath + ' ' + downloadURL;
         passon.result = {};
@@ -202,7 +239,8 @@ function zenodoLoad(passon) {
     });
 }
 
-/**TODO DELETE THIS CRAP
+/**
+ * Unused!
  * Loads multiple files from zenodo.org or sandbox.zenodo.org
  * @param {array} passon.zenodoFiles - Array of file(s) metadata from the zenodo dev API (developers.zenodo.org)
  * @param {string} passon.zenodoID - The zenodo record id.

--- a/lib/loader-steps.js
+++ b/lib/loader-steps.js
@@ -95,6 +95,12 @@ function publicShareLoad(passon) {
  */
 function checkZenodoContents(passon){
     return new Promise((fulfill, reject) => {
+        if (typeof passon.filename !== undefined) {
+            debug('Filename for record %s already specified. Continuing with download.', passon.zenodoID);
+            passon.zenodoLink = passon.baseURL + path.join('record/', passon.zenodoID, '/files/', passon.filename);
+            fulfill(passon);
+        }
+
         let requestURL = passon.baseURL + 'record/' + passon.zenodoID;
 
         https.get(requestURL, (res) => {
@@ -205,20 +211,8 @@ function checkZenodoContentsViaAPI(passon){
 function zenodoLoad(passon) {
     return new Promise((fulfill, reject) => {
         debug('Loading files from Zenodo');
-        let downloadURL;
-        if (passon.zenodoLink !== undefined) {
-            downloadURL = passon.zenodoLink;
-        } else if (passon.filename !== undefined) {
-            downloadURL = passon.baseURL + path.join('record/', passon.zenodoID, '/files/', passon.filename);
-        } else {
-            debug('No download link or filename provided');
-            let err = new Error('No download link or filename provided');
-            err.status = 404;
-            reject(err);
-        }
-
         var zipPath = path.join(config.fs.incoming, passon.id);
-        var cmd = 'wget -q -O ' + zipPath + ' ' + downloadURL;
+        var cmd = 'wget -q -O ' + zipPath + ' ' + passon.zenodoLink;
         passon.result = {};
         passon.result.zipName = passon.filename;
 

--- a/lib/loader-steps.js
+++ b/lib/loader-steps.js
@@ -19,11 +19,11 @@ const config = require('../config/config');
 const debug = require('debug')('loader');
 const exec = require('child_process').exec;
 const errorMessageHelper = require('../lib/error-message');
-const clone = require('clone');
+//const clone = require('clone');
 const nodemailer = require('nodemailer');
 
 const Compendium = require('../lib/model/compendium');
-const Stream = require('stream');
+//const Stream = require('stream');
 const path = require('path');
 const fs = require('fs');
 const url = require('url');
@@ -88,38 +88,38 @@ function saveFile(passon) {
 */
 
 function publicShareLoad(passon) {
-        debug('Loading file list from sciebo');
+    debug('Loading file list from sciebo');
 
-        // Extract owncloud share token from share URL
-        let token = url.parse(passon.shareURL).path.split('/')[3];
+    // Extract owncloud share token from share URL
+    let token = url.parse(passon.shareURL).path.split('/')[3];
 
-        //build webdav url for the client from share URL
-        let webdavURL = passon.shareURL.replace(new RegExp(/index.php\/s\/[a-zA-Z0-9]+/), config.webdav.urlString);
+    //build webdav url for the client from share URL
+    let webdavURL = passon.shareURL.replace(new RegExp(/index.php\/s\/[a-zA-Z0-9]+/), config.webdav.urlString);
 
-        passon.client = createClient(
-            webdavURL,
-            token,
-            ''
-        );
+    passon.client = createClient(
+        webdavURL,
+        token,
+        ''
+    );
 
-        /*  1. bagit.txt             -> download compendium as zip and continue
-            2. single zip file       -> download zip and continue
-            3. single directory      -> error (no compendium found)
-            4. multiple files        -> workspace (not implemented)
-            5. multiple directories  -> workspace (not implemented)
-        */
+    /*  1. bagit.txt             -> download compendium as zip and continue
+        2. single zip file       -> download zip and continue
+        3. single directory      -> error (no compendium found)
+        4. multiple files        -> workspace (not implemented)
+        5. multiple directories  -> workspace (not implemented)
+    */
 
-        return getContents(passon)
-        .then(analyzeContents)
-        .then(checkContents)
-        .then(checkAndCopyCompendium)
-        .then(checkAndLoadZip)
-        .then(checkAndLoadDirectory)
-        .then(loadWorkspace)
-        .catch(function (err) {
-            debug('Error loading public share: %s', err);
-            throw err;
-        });
+    return getContents(passon)
+    .then(analyzeContents)
+    .then(checkContents)
+    .then(checkAndCopyCompendium)
+    .then(checkAndLoadZip)
+    .then(checkAndLoadDirectory)
+    .then(loadWorkspace)
+    .catch(function (err) {
+        debug('Error loading public share: %s', err);
+        throw err;
+    });
 }
 
 function getContents(passon) {
@@ -137,7 +137,7 @@ function getContents(passon) {
             err.message = 'could not read webdav contents';
             reject(err);
         });
-    })
+    });
 }
 
 function analyzeContents(passon) {
@@ -152,7 +152,7 @@ function analyzeContents(passon) {
             length: 0
         };
 
-        for (i = 0; i < contents.length; i++) {
+        for (var i = 0; i < contents.length; i++) {
             if (contents[i].basename === 'bagit.txt') {
                 result.bagitCount++;
             }
@@ -161,7 +161,7 @@ function analyzeContents(passon) {
                 result.zipName = contents[i].basename;
                 if (result.zipName === 'webdav') { // return an error message if a zip file is submitted directly
                     debug('Direct file submission is not supported.');
-                    err = new Error('Direct file submission is not supported. Please submit a shared folder containing the file.');
+                    let err = new Error('Direct file submission is not supported. Please submit a shared folder containing the file.');
                     err.status = 404;
                     reject(err);
                 }
@@ -180,7 +180,7 @@ function analyzeContents(passon) {
 function checkContents(passon) {
     return new Promise((fulfill, reject) => {
         if (passon.result.length === 0) {
-            err = new Error('public share is empty');
+            let err = new Error('public share is empty');
             err.status = 404;
             reject(err);
         } else {
@@ -206,7 +206,7 @@ function checkAndCopyCompendium(passon) {
                     debug(error, stderr, stdout);
                     let errors = error.message.split(':');
                     let message = errorMessageHelper(errors[errors.length - 1]);
-                    error.message = JSON.stringify({ error: 'download failed: ' + message })
+                    error.message = JSON.stringify({ error: 'download failed: ' + message });
                     error.status = 500;
                     reject(error);
                 } else {
@@ -252,7 +252,7 @@ function checkAndLoadDirectory(passon) {
     //Check if a single directory exists -> throw error
     return new Promise((fulfill, reject) => {
         if (passon.result.directoryCount === 1 && passon.result.bagitCount === 0 && passon.result.zipCount !== 1) {
-            err = new Error('Single directory found. Use the "path" parameter to point to the compendium directory.');
+            let err = new Error('Single directory found. Use the "path" parameter to point to the compendium directory.');
             err.status = 404;
             reject(err);
         } else {
@@ -265,7 +265,7 @@ function loadWorkspace(passon) {
     //workspace not supported, implement here
     return new Promise((fulfill, reject) => {
         if (passon.result.directoryCount !== 1 && passon.result.bagitCount === 0 && passon.result.zipCount !== 1) {
-            err = new Error('workspace creation not implemented');
+            let err = new Error('workspace creation not implemented');
             err.status = 403;
             reject(err);
         } else {
@@ -302,7 +302,7 @@ function unzip(passon) {
                 debug(error, stderr, stdout);
                 let errors = error.message.split(':');
                 let message = errorMessageHelper(errors[errors.length - 1]);
-                error.message = JSON.stringify({ error: 'extraction failed: ' + message })
+                error.message = JSON.stringify({ error: 'extraction failed: ' + message });
                 error.status = 500;
                 reject(error);
             } else {
@@ -378,7 +378,7 @@ function extractMetadata(passon) {
     return new Promise((fulfill, reject) => {
         debug('Extracting metadata from %s', passon.id);
 
-        let metaextract_input_dir = path.join(passon.bagpath, config.bagtainer.payloadDirectory)
+        let metaextract_input_dir = path.join(passon.bagpath, config.bagtainer.payloadDirectory);
         let metaextract_output_dir = path.join(metaextract_input_dir, config.bagtainer.metaextract.outputDir);
 
         let cmd = [
@@ -400,7 +400,7 @@ function extractMetadata(passon) {
                 debug(error, stderr, stdout);
                 let errors = error.message.split(':');
                 let message = errorMessageHelper(errors[errors.length - 1]);
-                error.message = JSON.stringify({ error: 'metadata extraction failed: ' + message })
+                error.message = JSON.stringify({ error: 'metadata extraction failed: ' + message });
                 reject(error);
             } else {
                 debug('[%s] Completed metadata extraction:\n\n%s\n', passon.id, stdout);
@@ -512,7 +512,7 @@ function save(passon) {
         compendium.save(err => {
             if (err) {
                 debug('ERROR saving new compendium %s', passon.id);
-                err.message = JSON.stringify({ error: 'internal error' })
+                err.message = JSON.stringify({ error: 'internal error' });
                 err.status = 500;
                 reject(err);
             } else {

--- a/lib/loader-steps.js
+++ b/lib/loader-steps.js
@@ -19,17 +19,14 @@ const config = require('../config/config');
 const debug = require('debug')('loader');
 const exec = require('child_process').exec;
 const errorMessageHelper = require('../lib/error-message');
-//const clone = require('clone');
 const nodemailer = require('nodemailer');
 
 const Compendium = require('../lib/model/compendium');
-//const Stream = require('stream');
 const path = require('path');
 const fs = require('fs');
 const url = require('url');
 const createClient = require('webdav');
 const https = require('https');
-const request = require('request');
 
 if (config.bagtainer.scan.enable) {
     debug('Using clamscan with configuration %s', JSON.stringify(clam.settings));
@@ -105,30 +102,7 @@ function checkZenodoContents(passon){
         } else {
             requestURL += '?access_token=' + config.zenodo.token;
         }
-
         debug('Getting data on zenodo record %s with request %s', passon.zenodoID, requestURL);
-
-        // request
-        // .get(requestURL)
-        // .on('response', function(response) {
-        //     let data = JSON.parse(response);
-        //     if (data.files.length === 0) {
-        //         debug('No files found in zenodo deposit.');
-        //         let err = new Error('No files found in zenodo deposit.');
-        //         err.status = 404;
-        //         reject(err);                    
-        //     }
-        //     passon.zenodoFiles = [];
-        //     passon.zenodoFiles = data.files;
-        //     debug('Reading zenodo record completed');
-        //     fulfill(passon);
-        // })
-        // .on('error', function(err) {
-        //     debug('Loading file list failed, error: %s', err);
-        //     err.status = 404;
-        //     err.message = 'Loading file list failed';
-        //     reject(err); 
-        // });
 
         https.get(requestURL, (res) => {
             debug('Fetched zenodo contents, statusCode:', res.statusCode);

--- a/lib/loader-steps.js
+++ b/lib/loader-steps.js
@@ -241,6 +241,24 @@ function zenodoLoad(passon) {
     });
 }
 
+function getContents(passon) {
+    return new Promise((fulfill, reject) => {
+        passon.client
+        .getDirectoryContents(passon.webdav_path)
+        .then(function(contents) {
+            passon.contents = contents;
+            debug('Sucessfully loaded file list of %s', passon.shareURL);
+            fulfill(passon);
+        })
+        .catch(function (err) {
+            debug(err);
+            err.status = 404;
+            err.message = 'could not read webdav contents';
+            reject(err);
+        });
+    })
+}
+
 function analyzeContents(passon) {
     return new Promise((fulfill, reject) => {
 

--- a/lib/loader-steps.js
+++ b/lib/loader-steps.js
@@ -29,6 +29,7 @@ const fs = require('fs');
 const url = require('url');
 const createClient = require('webdav');
 const https = require('https');
+const request = require('request');
 
 if (config.bagtainer.scan.enable) {
     debug('Using clamscan with configuration %s', JSON.stringify(clam.settings));
@@ -93,32 +94,60 @@ function checkZenodoContents(passon){
     return new Promise((fulfill, reject) => {
         debug('Checking files in Zenodo deposit');
 
-        let requestURL = passon.baseURL + '/api/deposit/depositions/' + passon.zenodoID;
+        let requestURL = passon.baseURL + 'api/deposit/depositions/' + passon.zenodoID;
 
-        if (!config.zenodo.ZENODO_TOKEN){
+        if (!config.zenodo.token){
             debug('ZENODO_TOKEN not set');
             let err = new Error('ZENODO_TOKEN not set');
             err.status = 404;
             reject(err);
+            return;
         } else {
-            requestURL += '?ZENODO_TOKEN=' + config.zenodo.token;
+            requestURL += '?access_token=' + config.zenodo.token;
         }
+
+        debug('Getting data on zenodo record %s with request %s', passon.zenodoID, requestURL);
+
+        // request
+        // .get(requestURL)
+        // .on('response', function(response) {
+        //     let data = JSON.parse(response);
+        //     if (data.files.length === 0) {
+        //         debug('No files found in zenodo deposit.');
+        //         let err = new Error('No files found in zenodo deposit.');
+        //         err.status = 404;
+        //         reject(err);                    
+        //     }
+        //     passon.zenodoFiles = [];
+        //     passon.zenodoFiles = data.files;
+        //     debug('Reading zenodo record completed');
+        //     fulfill(passon);
+        // })
+        // .on('error', function(err) {
+        //     debug('Loading file list failed, error: %s', err);
+        //     err.status = 404;
+        //     err.message = 'Loading file list failed';
+        //     reject(err); 
+        // });
 
         https.get(requestURL, (res) => {
             debug('Fetched zenodo contents, statusCode:', res.statusCode);
 
             res.on('data', (d) => {
                 // check files length
-                if (d.files.length === 0) {
+                let data = JSON.parse(d);
+                if (data.files.length === 0) {
                     debug('No files found in zenodo deposit.');
                     let err = new Error('No files found in zenodo deposit.');
                     err.status = 404;
                     reject(err);                    
                 }
                 passon.zenodoFiles = [];
-                passon.zenodoFiles = d.files;
-                //passon.zenodoLink = d.files[0].links.download;
-                //process.stdout.write(d);
+                passon.zenodoFiles = data.files;
+                //passon.zenodoLink = data.files[0].links.download;
+                //process.stdout.write(data);
+                debug('Reading zenodo record completed');
+                fulfill(passon);
             });
 
         }).on('error', (e) => {
@@ -134,14 +163,15 @@ function checkZenodoContents(passon){
 function zenodoZipLoad(passon) {
     return new Promise((fulfill, reject) => {
         debug('Loading files from Zenodo');
+        var zipPath = path.join(config.fs.incoming, passon.id);
         var cmd = 'wget -q -O ' + zipPath + ' ';
 
         for (let i = 0; i < passon.zenodoFiles.length; i++) { // add all files from zenodo deposit to wget call
-            cmd += passon.zenodoFiles[i].filename;
+            // todo use base download URL from config  and replace ID and filename
+            cmd += passon.baseURL + path.join('record/', passon.zenodoID, '/files/', passon.zenodoFiles[i].filename);
         }
 
         // let downloadURL = passon.baseURL + path.join('record/', passon.zenodoID, '/files/', passon.filename);
-        var zipPath = path.join(config.fs.incoming, passon.id);
         // var cmd = 'wget -q -O ' + zipPath + ' ' + downloadURL;
         passon.result = {};
         passon.result.zipName = passon.zenodoFiles[0].filename;
@@ -597,5 +627,6 @@ module.exports = {
     save: save,
     cleanup: cleanup,
     publicShareLoad: publicShareLoad,
-    zenodoLoad: zenodoLoad
+    zenodoZipLoad: zenodoZipLoad,
+    checkZenodoContents: checkZenodoContents
 };

--- a/lib/loader-steps.js
+++ b/lib/loader-steps.js
@@ -95,19 +95,27 @@ function publicShareLoad(passon) {
  */
 function checkZenodoContents(passon){
     return new Promise((fulfill, reject) => {
-        if (typeof passon.filename !== undefined) {
+        if (typeof passon.filename !== 'undefined') {
             debug('Filename for record %s already specified. Continuing with download.', passon.zenodoID);
             passon.zenodoLink = passon.baseURL + path.join('record/', passon.zenodoID, '/files/', passon.filename);
             fulfill(passon);
+            return;
         }
 
         let requestURL = passon.baseURL + 'record/' + passon.zenodoID;
 
         https.get(requestURL, (res) => {
             debug('Fetched zenodo contents, statusCode:', res.statusCode);
+            if (res.statusCode !== 200) {
+                debug('Error: No Zenodo record found at %s!', requestURL);
+                let err = new Error('Zenodo record not found!');
+                err.status = 404;
+                reject(err);
+                return;      
+            }
 
             res.on('data', (d) => {
-                debug('Successfully loaded zenodo html document!');
+                debug('Loading zenodo html document...');
 
                 let zenodoLinks = [];
                 //parse the html document and extract links such as "<link rel="alternate" type="application/zip" href="https://sandbox.zenodo.org/record/69114/files/metatainer.zip">"
@@ -145,7 +153,7 @@ function checkZenodoContents(passon){
 }
 
 /**
- * Currently unused!
+ * Currently not in use!
  * Loads metadata (filenames, ...) from a zenodo deposit using the zenodo developer API.
  * Currently not used because the zenodo developer API only allows access to your personal files
  * @param {string} passon.zenodoID - The zenodo record id.
@@ -203,8 +211,7 @@ function checkZenodoContentsViaAPI(passon){
 
 /**
  * Loads a single file from zenodo.org or sandbox.zenodo.org
- * @param {string} passon.filename - The passon must contain the name of the file in the zenodo deposit...
- * @param {string} passon.zenodoLink - ... or the download link of the first zip file in the zenodo record.
+ * @param {string} passon.zenodoLink - The download link of the first zip file in the zenodo record.
  * @param {string} passon.zenodoID - The zenodo record id.
  * @param {string} passon.baseURL - The zenodo URL without a path (https://zenodo.org or https://sandbox.zenodo.org).
  */
@@ -214,7 +221,7 @@ function zenodoLoad(passon) {
         var zipPath = path.join(config.fs.incoming, passon.id);
         var cmd = 'wget -q -O ' + zipPath + ' ' + passon.zenodoLink;
         passon.result = {};
-        passon.result.zipName = passon.filename;
+        passon.result.zipName = passon.zenodoLink;
 
         debug('Downloading: "%s"', cmd);
         exec(cmd, (error, stdout, stderr) => {

--- a/lib/loader-steps.js
+++ b/lib/loader-steps.js
@@ -159,6 +159,12 @@ function analyzeContents(passon) {
             if (contents[i].mime === 'application/zip') {
                 result.zipCount++;
                 result.zipName = contents[i].basename;
+                if (result.zipName === 'webdav') { // return an error message if a zip file is submitted directly
+                    debug('Direct file submission is not supported.');
+                    err = new Error('Direct file submission is not supported. Please submit a shared folder containing the file.');
+                    err.status = 404;
+                    reject(err);
+                }
             }
             if (contents[i].type === 'directory') {
                 result.directoryCount++;
@@ -180,7 +186,7 @@ function checkContents(passon) {
         } else {
             fulfill(passon);
         }
-    }); 
+    });
 }
 
 function checkAndCopyCompendium(passon) {
@@ -230,6 +236,12 @@ function checkAndLoadZip(passon) {
                         }
                     });
                 })
+                .catch(function (err) {
+                    debug(err);
+                    err.status = 404;
+                    err.message = 'could not download zip file';
+                    reject(err);
+                });
         } else {
             fulfill(passon);
         }

--- a/lib/loader-steps.js
+++ b/lib/loader-steps.js
@@ -93,7 +93,7 @@ function publicShareLoad(passon) {
     // Extract owncloud share token from share URL
     let token = url.parse(passon.shareURL).path.split('/')[3];
 
-    //build webdav url for the client from share URL
+    //build webdav url for the client from share URL (replace "/index.php/s/<share_token>" with "public.php/webdav")
     let webdavURL = passon.shareURL.replace(new RegExp(/index.php\/s\/[a-zA-Z0-9]+/), config.webdav.urlString);
 
     passon.client = createClient(
@@ -124,11 +124,12 @@ function publicShareLoad(passon) {
 
 function zenodoLoad(passon) {
     return new Promise((fulfill, reject) => {
-        debug('Loading file list from zenodo');
-        // todo: load files from zenodo (wget)
-        let downloadURL = path.join(passon.baseURL, '/record/', passon.zenodoID, '/files/', passon.filename);
+        debug('Loading files from Zenodo');
+        let downloadURL = passon.baseURL + path.join('record/', passon.zenodoID, '/files/', passon.filename);
         var zipPath = path.join(config.fs.incoming, passon.id);
         var cmd = 'wget -q -O ' + zipPath + ' ' + downloadURL;
+        passon.result = {};
+        passon.result.zipName = passon.filename;
 
         debug('Downloading: "%s"', cmd);
         exec(cmd, (error, stdout, stderr) => {
@@ -580,5 +581,6 @@ module.exports = {
     brokerMetadata: brokerMetadata,
     save: save,
     cleanup: cleanup,
-    publicShareLoad: publicShareLoad
+    publicShareLoad: publicShareLoad,
+    zenodoLoad: zenodoLoad
 };

--- a/lib/loader-steps.js
+++ b/lib/loader-steps.js
@@ -139,6 +139,7 @@ function checkZenodoContents(passon){
 }
 
 /**
+ * Currently unused!
  * Loads metadata (filenames, ...) from a zenodo deposit using the zenodo developer API.
  * Currently not used because the zenodo developer API only allows access to your personal files
  * @param {string} passon.zenodoID - The zenodo record id.
@@ -196,8 +197,8 @@ function checkZenodoContentsViaAPI(passon){
 
 /**
  * Loads a single file from zenodo.org or sandbox.zenodo.org
- * @param {string} passon.filename - Name of the file in the zenodo deposit.
- * @param {string} passon.zenodoLink - Download link of the first zip file in the zenodo record
+ * @param {string} passon.filename - The passon must contain the name of the file in the zenodo deposit...
+ * @param {string} passon.zenodoLink - ... or the download link of the first zip file in the zenodo record.
  * @param {string} passon.zenodoID - The zenodo record id.
  * @param {string} passon.baseURL - The zenodo URL without a path (https://zenodo.org or https://sandbox.zenodo.org).
  */
@@ -235,63 +236,6 @@ function zenodoLoad(passon) {
                 passon.zipPath = zipPath;
                 fulfill(passon);
             }
-        });
-    });
-}
-
-/**
- * Unused!
- * Loads multiple files from zenodo.org or sandbox.zenodo.org
- * @param {array} passon.zenodoFiles - Array of file(s) metadata from the zenodo dev API (developers.zenodo.org)
- * @param {string} passon.zenodoID - The zenodo record id.
- */
-function zenodoZipLoad(passon) {
-    return new Promise((fulfill, reject) => {
-        debug('Loading files from Zenodo');
-        var zipPath = path.join(config.fs.incoming, passon.id);
-        var cmd = 'wget -q -O ' + zipPath + ' ';
-
-        for (let i = 0; i < passon.zenodoFiles.length; i++) { // add all files from zenodo deposit to wget call
-            // todo use base download URL from config  and replace ID and filename
-            // TODO only load first file and give notification
-            cmd += passon.baseURL + path.join('record/', passon.zenodoID, '/files/', passon.zenodoFiles[i].filename);
-        }
-
-        passon.result = {};
-        passon.result.zipName = passon.zenodoFiles[0].filename;
-
-        debug('Downloading: "%s"', cmd);
-        exec(cmd, (error, stdout, stderr) => {
-            if (error || stderr) {
-                debug(error, stderr, stdout);
-                let errors = error.message.split(':');
-                let message = errorMessageHelper(errors[errors.length - 1]);
-                error.message = JSON.stringify({ error: 'download failed: ' + message });
-                error.status = 500;
-                reject(error);
-            } else {
-                debug('Download of zenodo record %s complete!', passon.id);
-                passon.zipPath = zipPath;
-                fulfill(passon);
-            }
-        });
-    });
-}
-
-function getContents(passon) {
-    return new Promise((fulfill, reject) => {
-        passon.client
-        .getDirectoryContents(passon.webdav_path)
-        .then(function(contents) {
-            passon.contents = contents;
-            debug('Sucessfully loaded file list of %s', passon.shareURL);
-            fulfill(passon);
-        })
-        .catch(function (err) {
-            debug(err);
-            err.status = 404;
-            err.message = 'could not read webdav contents';
-            reject(err);
         });
     });
 }
@@ -711,6 +655,6 @@ module.exports = {
     save: save,
     cleanup: cleanup,
     publicShareLoad: publicShareLoad,
-    zenodoZipLoad: zenodoZipLoad,
+    zenodoLoad: zenodoLoad,
     checkZenodoContents: checkZenodoContents
 };

--- a/lib/loader-steps.js
+++ b/lib/loader-steps.js
@@ -91,18 +91,18 @@ function publicShareLoad(passon) {
 /**
  * Loads filename(s) from the zenodo record by parsing the HTML document
  * @param {string} passon.zenodoID - The zenodo record id.
- * @param {string} config.zenodo.url - The zenodo URL without a path (https://zenodo.org or https://sandbox.zenodo.org).
+ * @param {string} passon.baseURL - The zenodo URL without a path (https://zenodo.org or https://sandbox.zenodo.org).
  */
 function checkZenodoContents(passon){
     return new Promise((fulfill, reject) => {
         if (typeof passon.filename !== 'undefined') {
             debug('Filename for record %s already specified. Continuing with download.', passon.zenodoID);
-            passon.zenodoLink = config.zenodo.url + path.join('record/', passon.zenodoID, '/files/', passon.filename);
+            passon.zenodoLink = passon.baseURL + path.join('record/', passon.zenodoID, '/files/', passon.filename);
             fulfill(passon);
             return;
         }
 
-        let requestURL = config.zenodo.url + 'record/' + passon.zenodoID;
+        let requestURL = passon.baseURL + 'record/' + passon.zenodoID;
 
         https.get(requestURL, (res) => {
             debug('Fetched zenodo contents, statusCode:', res.statusCode);
@@ -157,14 +157,14 @@ function checkZenodoContents(passon){
  * Loads metadata (filenames, ...) from a zenodo deposit using the zenodo developer API.
  * Currently not used because the zenodo developer API only allows access to your personal files
  * @param {string} passon.zenodoID - The zenodo record id.
- * @param {string} config.zenodo.url - The zenodo URL without a path (https://zenodo.org or https://sandbox.zenodo.org).
+ * @param {string} passon.baseURL - The zenodo URL without a path (https://zenodo.org or https://sandbox.zenodo.org).
  * @param {string} config.zenodo.token - The user's zenodo dev access_token
  */
 function checkZenodoContentsViaAPI(passon){
     return new Promise((fulfill, reject) => {
         debug('Checking files in Zenodo deposit');
 
-        let requestURL = config.zenodo.url + 'api/deposit/depositions/' + passon.zenodoID;
+        let requestURL = passon.baseURL + 'api/deposit/depositions/' + passon.zenodoID;
 
         if (!config.zenodo.token){
             debug('ZENODO_TOKEN not set');
@@ -213,7 +213,6 @@ function checkZenodoContentsViaAPI(passon){
  * Loads a single file from zenodo.org or sandbox.zenodo.org
  * @param {string} passon.zenodoLink - The download link of the first zip file in the zenodo record.
  * @param {string} passon.zenodoID - The zenodo record id.
- * @param {string} config.zenodo.url - The zenodo URL without a path (https://zenodo.org or https://sandbox.zenodo.org).
  */
 function zenodoLoad(passon) {
     return new Promise((fulfill, reject) => {

--- a/lib/loader-steps.js
+++ b/lib/loader-steps.js
@@ -27,6 +27,8 @@ const fs = require('fs');
 const url = require('url');
 const createClient = require('webdav');
 const https = require('https');
+const scrape = require('html-metadata');
+
 
 if (config.bagtainer.scan.enable) {
     debug('Using clamscan with configuration %s', JSON.stringify(clam.settings));
@@ -87,7 +89,38 @@ function publicShareLoad(passon) {
     });
 }
 
+/**
+ * Loads filename(s) from the zenodo record by reading the HTML headers
+ * @param {string} passon.zenodoID - The zenodo record id.
+ * @param {string} passon.baseURL - The zenodo URL without a path (https://zenodo.org or https://sandbox.zenodo.org).
+ */
 function checkZenodoContents(passon){
+    return new Promise((fulfill, reject) => {
+ 
+        var url = 'https://sandbox.zenodo.org/record/18401';
+        
+        scrape(url)
+        .then(function(metadata){
+            debug(metadata);
+            fulfill(passon);
+        })
+        .catch(function (err) {
+            debug(err);
+            err.status = 404;
+            err.message = 'Could not read zenodo record contents';
+            reject(err);
+        });
+    });
+}
+
+/**
+ * Loads metadata (filenames, ...) from a zenodo deposit using the zenodo developer API.
+ * Currently not used because the zenodo developer API only allows access to your personal files
+ * @param {string} passon.zenodoID - The zenodo record id.
+ * @param {string} passon.baseURL - The zenodo URL without a path (https://zenodo.org or https://sandbox.zenodo.org).
+ * @param {string} config.zenodo.token - The user's zenodo dev access_token
+ */
+function checkZenodoContentsViaAPI(passon){
     return new Promise((fulfill, reject) => {
         debug('Checking files in Zenodo deposit');
 
@@ -118,6 +151,7 @@ function checkZenodoContents(passon){
                 }
                 passon.zenodoFiles = [];
                 passon.zenodoFiles = data.files;
+                passon.filename = data.files[0].filename;
                 //passon.zenodoLink = data.files[0].links.download;
                 //process.stdout.write(data);
                 debug('Reading zenodo record completed');
@@ -134,6 +168,45 @@ function checkZenodoContents(passon){
     });
 }
 
+
+/**
+ * Loads a single file from zenodo.org or sandbox.zenodo.org
+ * @param {string} passon.filename - Name of the file in the zenodo deposit.
+ * @param {string} passon.zenodoID - The zenodo record id.
+ * @param {string} passon.baseURL - The zenodo URL without a path (https://zenodo.org or https://sandbox.zenodo.org).
+ */
+function zenodoLoad(passon) {
+    return new Promise((fulfill, reject) => {
+        debug('Loading files from Zenodo');
+        let downloadURL = passon.baseURL + path.join('record/', passon.zenodoID, '/files/', passon.filename);
+        var zipPath = path.join(config.fs.incoming, passon.id);
+        var cmd = 'wget -q -O ' + zipPath + ' ' + downloadURL;
+        passon.result = {};
+        passon.result.zipName = passon.filename;
+
+        debug('Downloading: "%s"', cmd);
+        exec(cmd, (error, stdout, stderr) => {
+            if (error || stderr) {
+                debug(error, stderr, stdout);
+                let errors = error.message.split(':');
+                let message = errorMessageHelper(errors[errors.length - 1]);
+                error.message = JSON.stringify({ error: 'download failed: ' + message });
+                error.status = 500;
+                reject(error);
+            } else {
+                debug('Download of zenodo record %s complete!', passon.id);
+                passon.zipPath = zipPath;
+                fulfill(passon);
+            }
+        });
+    });
+}
+
+/**TODO DELETE THIS CRAP
+ * Loads multiple files from zenodo.org or sandbox.zenodo.org
+ * @param {array} passon.zenodoFiles - Array of file(s) metadata from the zenodo dev API (developers.zenodo.org)
+ * @param {string} passon.zenodoID - The zenodo record id.
+ */
 function zenodoZipLoad(passon) {
     return new Promise((fulfill, reject) => {
         debug('Loading files from Zenodo');
@@ -142,11 +215,10 @@ function zenodoZipLoad(passon) {
 
         for (let i = 0; i < passon.zenodoFiles.length; i++) { // add all files from zenodo deposit to wget call
             // todo use base download URL from config  and replace ID and filename
+            // TODO only load first file and give notification
             cmd += passon.baseURL + path.join('record/', passon.zenodoID, '/files/', passon.zenodoFiles[i].filename);
         }
 
-        // let downloadURL = passon.baseURL + path.join('record/', passon.zenodoID, '/files/', passon.filename);
-        // var cmd = 'wget -q -O ' + zipPath + ' ' + downloadURL;
         passon.result = {};
         passon.result.zipName = passon.zenodoFiles[0].filename;
 

--- a/lib/loader-steps.js
+++ b/lib/loader-steps.js
@@ -91,18 +91,18 @@ function publicShareLoad(passon) {
 /**
  * Loads filename(s) from the zenodo record by parsing the HTML document
  * @param {string} passon.zenodoID - The zenodo record id.
- * @param {string} passon.baseURL - The zenodo URL without a path (https://zenodo.org or https://sandbox.zenodo.org).
+ * @param {string} config.zenodo.url - The zenodo URL without a path (https://zenodo.org or https://sandbox.zenodo.org).
  */
 function checkZenodoContents(passon){
     return new Promise((fulfill, reject) => {
         if (typeof passon.filename !== 'undefined') {
             debug('Filename for record %s already specified. Continuing with download.', passon.zenodoID);
-            passon.zenodoLink = passon.baseURL + path.join('record/', passon.zenodoID, '/files/', passon.filename);
+            passon.zenodoLink = config.zenodo.url + path.join('record/', passon.zenodoID, '/files/', passon.filename);
             fulfill(passon);
             return;
         }
 
-        let requestURL = passon.baseURL + 'record/' + passon.zenodoID;
+        let requestURL = config.zenodo.url + 'record/' + passon.zenodoID;
 
         https.get(requestURL, (res) => {
             debug('Fetched zenodo contents, statusCode:', res.statusCode);
@@ -157,14 +157,14 @@ function checkZenodoContents(passon){
  * Loads metadata (filenames, ...) from a zenodo deposit using the zenodo developer API.
  * Currently not used because the zenodo developer API only allows access to your personal files
  * @param {string} passon.zenodoID - The zenodo record id.
- * @param {string} passon.baseURL - The zenodo URL without a path (https://zenodo.org or https://sandbox.zenodo.org).
+ * @param {string} config.zenodo.url - The zenodo URL without a path (https://zenodo.org or https://sandbox.zenodo.org).
  * @param {string} config.zenodo.token - The user's zenodo dev access_token
  */
 function checkZenodoContentsViaAPI(passon){
     return new Promise((fulfill, reject) => {
         debug('Checking files in Zenodo deposit');
 
-        let requestURL = passon.baseURL + 'api/deposit/depositions/' + passon.zenodoID;
+        let requestURL = config.zenodo.url + 'api/deposit/depositions/' + passon.zenodoID;
 
         if (!config.zenodo.token){
             debug('ZENODO_TOKEN not set');
@@ -213,7 +213,7 @@ function checkZenodoContentsViaAPI(passon){
  * Loads a single file from zenodo.org or sandbox.zenodo.org
  * @param {string} passon.zenodoLink - The download link of the first zip file in the zenodo record.
  * @param {string} passon.zenodoID - The zenodo record id.
- * @param {string} passon.baseURL - The zenodo URL without a path (https://zenodo.org or https://sandbox.zenodo.org).
+ * @param {string} config.zenodo.url - The zenodo URL without a path (https://zenodo.org or https://sandbox.zenodo.org).
  */
 function zenodoLoad(passon) {
     return new Promise((fulfill, reject) => {

--- a/lib/loader-steps.js
+++ b/lib/loader-steps.js
@@ -126,6 +126,25 @@ function zenodoLoad(passon) {
     return new Promise((fulfill, reject) => {
         debug('Loading file list from zenodo');
         // todo: load files from zenodo (wget)
+        let downloadURL = path.join(passon.baseURL, '/record/', passon.zenodoID, '/files/', passon.filename);
+        var zipPath = path.join(config.fs.incoming, passon.id);
+        var cmd = 'wget -q -O ' + zipPath + ' ' + downloadURL;
+
+        debug('Downloading: "%s"', cmd);
+        exec(cmd, (error, stdout, stderr) => {
+            if (error || stderr) {
+                debug(error, stderr, stdout);
+                let errors = error.message.split(':');
+                let message = errorMessageHelper(errors[errors.length - 1]);
+                error.message = JSON.stringify({ error: 'download failed: ' + message });
+                error.status = 500;
+                reject(error);
+            } else {
+                debug('Download of zenodo record %s complete!', passon.id);
+                passon.zipPath = zipPath;
+                fulfill(passon);
+            }
+        });
     });
 }
 

--- a/lib/loader-steps.js
+++ b/lib/loader-steps.js
@@ -122,6 +122,13 @@ function publicShareLoad(passon) {
     });
 }
 
+function zenodoLoad(passon) {
+    return new Promise((fulfill, reject) => {
+        debug('Loading file list from zenodo');
+        // todo: load files from zenodo (wget)
+    });
+}
+
 function getContents(passon) {
     return new Promise((fulfill, reject) => {
         passon.client

--- a/lib/loader-steps.js
+++ b/lib/loader-steps.js
@@ -100,11 +100,12 @@ function checkZenodoContents(passon){
             let err = new Error('ZENODO_TOKEN not set');
             err.status = 404;
             reject(err);
+        } else {
+            requestURL += '?ZENODO_TOKEN=' + config.zenodo.token;
         }
 
         https.get(requestURL, (res) => {
-            console.log('statusCode:', res.statusCode);
-            console.log('headers:', res.headers);
+            debug('Fetched zenodo contents, statusCode:', res.statusCode);
 
             res.on('data', (d) => {
                 // check files length

--- a/lib/loader-steps.js
+++ b/lib/loader-steps.js
@@ -28,8 +28,7 @@ const path = require('path');
 const fs = require('fs');
 const url = require('url');
 const createClient = require('webdav');
-
-
+const https = require('https');
 
 if (config.bagtainer.scan.enable) {
     debug('Using clamscan with configuration %s', JSON.stringify(clam.settings));
@@ -54,38 +53,6 @@ if (config.bagtainer.scan.email.enable
 } else {
     debug('Email notification for virus detection _not_ active: %s', JSON.stringify(config.bagtainer.scan.email));
 }
-
-/*
-    //currently not used & not working
-    //recursively sync webdav files
-function saveWebdav(passon) {
-
-    return getContents(passon).then(function(passon) {
-        return Promise.all(passon.contents.map(function (e) {
-            if(e.type === 'file') {
-                return saveFile(e);
-            } else if (e.type === 'directory') {
-                passon.remotePath = e.basename;
-                return saveWebdav(passon);
-            }
-        }))
-    })
-    .catch(function(err) {
-        debug(err);
-    });
-}
-    
-function saveFile(passon) {
-    //currently not used
-    return new Promise((fulfill, reject) => {
-        passon.client
-        .getFileContents(passon.filename)
-        .then(function (file) {
-            fs.writeFile(path.join(passon.localPath, passon.remotePath, passon.basename), file);
-        });
-    });
-}
-*/
 
 function publicShareLoad(passon) {
     debug('Loading file list from sciebo');
@@ -122,14 +89,61 @@ function publicShareLoad(passon) {
     });
 }
 
-function zenodoLoad(passon) {
+function checkZenodoContents(passon){
+    return new Promise((fulfill, reject) => {
+        debug('Checking files in Zenodo deposit');
+
+        let requestURL = passon.baseURL + '/api/deposit/depositions/' + passon.zenodoID;
+
+        if (!config.zenodo.ZENODO_TOKEN){
+            debug('ZENODO_TOKEN not set');
+            let err = new Error('ZENODO_TOKEN not set');
+            err.status = 404;
+            reject(err);
+        }
+
+        https.get(requestURL, (res) => {
+            console.log('statusCode:', res.statusCode);
+            console.log('headers:', res.headers);
+
+            res.on('data', (d) => {
+                // check files length
+                if (d.files.length === 0) {
+                    debug('No files found in zenodo deposit.');
+                    let err = new Error('No files found in zenodo deposit.');
+                    err.status = 404;
+                    reject(err);                    
+                }
+                passon.zenodoFiles = [];
+                passon.zenodoFiles = d.files;
+                //passon.zenodoLink = d.files[0].links.download;
+                //process.stdout.write(d);
+            });
+
+        }).on('error', (e) => {
+            debug('Loading file list failed, error: %s', e);
+            e.status = 404;
+            e.message = 'Loading file list failed';
+            reject(e); 
+        });
+
+    });
+}
+
+function zenodoZipLoad(passon) {
     return new Promise((fulfill, reject) => {
         debug('Loading files from Zenodo');
-        let downloadURL = passon.baseURL + path.join('record/', passon.zenodoID, '/files/', passon.filename);
+        var cmd = 'wget -q -O ' + zipPath + ' ';
+
+        for (let i = 0; i < passon.zenodoFiles.length; i++) { // add all files from zenodo deposit to wget call
+            cmd += passon.zenodoFiles[i].filename;
+        }
+
+        // let downloadURL = passon.baseURL + path.join('record/', passon.zenodoID, '/files/', passon.filename);
         var zipPath = path.join(config.fs.incoming, passon.id);
-        var cmd = 'wget -q -O ' + zipPath + ' ' + downloadURL;
+        // var cmd = 'wget -q -O ' + zipPath + ' ' + downloadURL;
         passon.result = {};
-        passon.result.zipName = passon.filename;
+        passon.result.zipName = passon.zenodoFiles[0].filename;
 
         debug('Downloading: "%s"', cmd);
         exec(cmd, (error, stdout, stderr) => {

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -81,7 +81,6 @@ function Loader(req, res) {
             id: randomstring.generate(c.id_length),
             zenodoURL: encodeURI(this.req.body.share_url),
             zenodoID: this.req.params.zenodoID,
-            baseURL: this.req.params.baseURL,
             filename: this.req.body.filename,
             user: this.req.user.orcid,
             req: this.req,

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -45,8 +45,6 @@ function Loader(req, res) {
         };
 
         debug('[%s] Docker client set up: %s', passon.id, JSON.stringify(passon.docker));
-
-        // TODO: decide what to do based on file structure
         
         return steps.publicShareLoad(passon)
             .then(steps.unzip)
@@ -74,7 +72,49 @@ function Loader(req, res) {
                 done(null, err);
                 res.status(status).send(JSON.stringify({ error: msg }));
             });
-    }
+    };
+
+    this.loadZenodo = (done) => {
+        debug('Handling zenodo load of %s for user %s', this.req.body.zenodoURL, this.req.user.orcid);
+
+        let passon = {
+            id: randomstring.generate(c.id_length),
+            zenodoURL: encodeURI(this.req.body.zenodo_url),
+            user: this.req.user.orcid,
+            req: this.req,
+            res: this.res,
+            docker: new Docker() // setup Docker client with default options
+        };
+
+        debug('[%s] Docker client set up: %s', passon.id, JSON.stringify(passon.docker));
+        
+        return steps.zenodoLoad(passon)
+            .then(steps.unzip)
+            .then(steps.extractMetadata)
+            .then(steps.loadMetadata)
+            .then(steps.brokerMetadata)
+            .then(steps.save)
+            .then(steps.cleanup)
+            .then(this.respond)
+            .then((passon) => {
+                debug('[%s] completed zenodo load', passon.id);
+                done(passon.id, null);
+            })
+            .catch(err => {
+                debug('Rejection or unhandled failure during execute: \n\t%s',
+                JSON.stringify(err));
+                let status = 500;
+                if (err.status) {
+                    status = err.status;
+                }
+                let msg = 'Internal error';
+                if (err.message) {
+                    msg = err.message;
+                }
+                done(null, err);
+                res.status(status).send(JSON.stringify({ error: msg }));
+            });
+    };
 
     this.respond = (passon) => {
         return new Promise((fulfill) => {
@@ -82,7 +122,7 @@ function Loader(req, res) {
             debug('New compendium %s', passon.id);
             fulfill(passon);
         });
-    }
+    };
 }
 
 module.exports.Loader = Loader;

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -81,7 +81,7 @@ function Loader(req, res) {
             id: randomstring.generate(c.id_length),
             zenodoURL: encodeURI(this.req.body.share_url),
             zenodoID: this.req.body.zenodo_id,
-            baseURL: this.req.body.base_url,
+            baseURL: this.req.params.base_url,
             filename: this.req.body.filename,
             user: this.req.user.orcid,
             req: this.req,

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -80,6 +80,9 @@ function Loader(req, res) {
         let passon = {
             id: randomstring.generate(c.id_length),
             zenodoURL: encodeURI(this.req.body.zenodo_url),
+            zenodoID: this.req.body.zenodo_id,
+            baseURL: this.req.body.base_url,
+            filename: this.req.body.filename,
             user: this.req.user.orcid,
             req: this.req,
             res: this.res,

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -83,6 +83,8 @@ function Loader(req, res) {
             zenodoID: this.req.params.zenodo_id,
             baseURL: this.req.params.base_url,
             filename: this.req.body.filename,
+            doi: this.req.body.doi,
+            recordID: this.req.body.zenodo_record_id,
             user: this.req.user.orcid,
             req: this.req,
             res: this.res,

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -81,6 +81,7 @@ function Loader(req, res) {
             id: randomstring.generate(c.id_length),
             zenodoURL: encodeURI(this.req.body.share_url),
             zenodoID: this.req.params.zenodoID,
+            baseURL: this.req.params.baseURL,
             filename: this.req.body.filename,
             user: this.req.user.orcid,
             req: this.req,

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -92,7 +92,7 @@ function Loader(req, res) {
         debug('[%s] Docker client set up: %s', passon.id, JSON.stringify(passon.docker));
         
         return steps.checkZenodoContents(passon)
-            .then(steps.zenodoLoad)
+            .then(steps.zenodoZipLoad)
             .then(steps.unzip)
             .then(steps.extractMetadata)
             .then(steps.loadMetadata)

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -80,11 +80,9 @@ function Loader(req, res) {
         let passon = {
             id: randomstring.generate(c.id_length),
             zenodoURL: encodeURI(this.req.body.share_url),
-            zenodoID: this.req.params.zenodo_id,
-            baseURL: this.req.params.base_url,
+            zenodoID: this.req.params.zenodoID,
+            baseURL: this.req.params.baseURL,
             filename: this.req.body.filename,
-            doi: this.req.body.doi,
-            recordID: this.req.body.zenodo_record_id,
             user: this.req.user.orcid,
             req: this.req,
             res: this.res,

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -79,7 +79,7 @@ function Loader(req, res) {
 
         let passon = {
             id: randomstring.generate(c.id_length),
-            zenodoURL: encodeURI(this.req.body.zenodo_url),
+            zenodoURL: encodeURI(this.req.body.share_url),
             zenodoID: this.req.body.zenodo_id,
             baseURL: this.req.body.base_url,
             filename: this.req.body.filename,
@@ -91,7 +91,8 @@ function Loader(req, res) {
 
         debug('[%s] Docker client set up: %s', passon.id, JSON.stringify(passon.docker));
         
-        return steps.zenodoLoad(passon)
+        return steps.checkZenodoContents(passon)
+            .then(steps.zenodoLoad)
             .then(steps.unzip)
             .then(steps.extractMetadata)
             .then(steps.loadMetadata)

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -80,7 +80,7 @@ function Loader(req, res) {
         let passon = {
             id: randomstring.generate(c.id_length),
             zenodoURL: encodeURI(this.req.body.share_url),
-            zenodoID: this.req.body.zenodo_id,
+            zenodoID: this.req.params.zenodo_id,
             baseURL: this.req.params.base_url,
             filename: this.req.body.filename,
             user: this.req.user.orcid,

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -31,7 +31,7 @@ function Loader(req, res) {
     this.req = req;
     this.res = res;
 
-    this.load = (done) => {
+    this.loadOwncloud = (done) => {
         debug('Handling public share load of %s for user %s', this.req.body.share_url, this.req.user.orcid);
 
         let passon = {
@@ -92,7 +92,7 @@ function Loader(req, res) {
         debug('[%s] Docker client set up: %s', passon.id, JSON.stringify(passon.docker));
         
         return steps.checkZenodoContents(passon)
-            .then(steps.zenodoZipLoad)
+            .then(steps.zenodoLoad)
             .then(steps.unzip)
             .then(steps.extractMetadata)
             .then(steps.loadMetadata)

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "request": "^2.79.0",
     "response-time": "^2.3.2",
     "validator": "^6.2.1",
-    "webdav": "^0.1.1"
+    "webdav": "^0.1.1",
+    "html-metadata": "^1.6.3"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "express": "^4.14.0",
     "express-session": "^1.14.0",
     "fs-extra": "^0.30.0",
+    "htmlparser2": "^3.9.2",
     "mimos": "^3.0.3",
     "mongoose": "^4.5.5",
     "mongoose-timestamp": "^0.6.0",
@@ -41,8 +42,7 @@
     "request": "^2.79.0",
     "response-time": "^2.3.2",
     "validator": "^6.2.1",
-    "webdav": "^0.1.1",
-    "html-metadata": "^1.6.3"
+    "webdav": "^0.1.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/test/sciebo.js
+++ b/test/sciebo.js
@@ -68,7 +68,7 @@ describe('API basics', function () {
 
         it('public share with single directory: should throw an error and notify that the directory contains no files', (done) => {
             let form = {
-                share_url: 'https://uni-muenster.sciebo.de/index.php/s/kg31BEkkwNgQWRi',
+                share_url: 'https://uni-muenster.sciebo.de/index.php/s/pnKnjIjas9bZgbB',
                 path: '/',
                 content_type: 'compendium_v1',
             };

--- a/test/sciebo.js
+++ b/test/sciebo.js
@@ -8,7 +8,7 @@ const cookie = 's:C0LIrsxGtHOGHld8Nv2jedjL4evGgEHo.GMsWD5Vveq0vBt7/4rGeoH5Xx7Dd2
 const requestLoadingTimeout = 20000;
 
 
-describe('API basics', function () {
+describe('Sciebo loader basics', function () {
 
     var compendium_id = '';
 

--- a/test/sciebo.js
+++ b/test/sciebo.js
@@ -111,14 +111,14 @@ describe('API basics', function () {
                 timeout: requestLoadingTimeout
             }, (err, res, body) => {
                 assert.ifError(err);
-                assert.equal(res.statusCode, 404);
+                assert.equal(res.statusCode, 403);
                 assert.isUndefined(JSON.parse(body).id, 'returned no id');
                 assert.propertyVal(JSON.parse(body), 'error', 'workspace creation not implemented');
                 done();
             });
         }).timeout(10000);
 
-        it('invalid share URL: should respond with an error 404', (done) => {
+        it('invalid share URL: should respond with an error 422', (done) => {
             let form = {
                 share_url: 'htts:/uni-muenster.sciebo.de/index.php/s/7EoWgjLSFV',
                 path: '/',
@@ -137,7 +137,7 @@ describe('API basics', function () {
                 timeout: requestLoadingTimeout
             }, (err, res, body) => {
                 assert.ifError(err);
-                assert.equal(res.statusCode, 404);
+                assert.equal(res.statusCode, 422);
                 assert.isUndefined(JSON.parse(body).id, 'returned no id');
                 assert.propertyVal(JSON.parse(body), 'error', 'public share URL is invalid');
                 done();

--- a/test/sciebo.js
+++ b/test/sciebo.js
@@ -165,7 +165,7 @@ describe('API basics', function () {
                 assert.ifError(err);
                 assert.equal(res.statusCode, 403);
                 assert.isUndefined(JSON.parse(body).id, 'returned no id');
-                assert.propertyVal(JSON.parse(body), 'error', 'public share host is not allowed');
+                assert.propertyVal(JSON.parse(body), 'error', 'host is not allowed');
                 done();
             });
         }).timeout(10000);

--- a/test/sciebo.js
+++ b/test/sciebo.js
@@ -111,7 +111,7 @@ describe('API basics', function () {
                 timeout: requestLoadingTimeout
             }, (err, res, body) => {
                 assert.ifError(err);
-                assert.equal(res.statusCode, 403);
+                assert.equal(res.statusCode, 404);
                 assert.isUndefined(JSON.parse(body).id, 'returned no id');
                 assert.propertyVal(JSON.parse(body), 'error', 'workspace creation not implemented');
                 done();

--- a/test/zenodo.js
+++ b/test/zenodo.js
@@ -15,7 +15,7 @@ describe('API basics', function () {
     describe('create new compendium based on a zenodo record', () => {
         it('zenodo record with zip file: should respond with a compendium ID', (done) => {
             let form = {
-                zenodo_url: 'https://sandbox.zenodo.org/record/69114',
+                share_url: 'https://sandbox.zenodo.org/record/69114',
                 filename: 'metatainer.zip',
                 content_type: 'compendium_v1'
             };
@@ -42,7 +42,7 @@ describe('API basics', function () {
 
         it('invalid zenodo URL: should respond with an error 404', (done) => {
             let form = {
-                zenodo_url: 'htts://sandbox.zenodo.org/record/69114',
+                share_url: 'htts://sandbox.zenodo.org/record/69114',
                 filename: 'metatainer.zip',
                 content_type: 'compendium_v1',
             };
@@ -68,7 +68,7 @@ describe('API basics', function () {
 
         it('invalid host (not a zenodo record): should respond with an error 403', (done) => {
             let form = {
-                zenodo_url: 'https://sandbox.ODONEZ.org/record/69114',
+                share_url: 'https://sandbox.ODONEZ.org/record/69114',
                 filename: 'metatainer.zip',
                 content_type: 'compendium_v1',
             };
@@ -94,7 +94,7 @@ describe('API basics', function () {
 
         it('filename not found: should respond with an error 500', (done) => {
             let form = {
-                zenodo_url: 'https://sandbox.zenodo.org/record/69114',
+                share_url: 'https://sandbox.zenodo.org/record/69114',
                 filename: 'not_existing_file.xyz',
                 content_type: 'compendium_v1',
             };

--- a/test/zenodo.js
+++ b/test/zenodo.js
@@ -117,6 +117,8 @@ describe('API basics', function () {
                 done();
             });
         }).timeout(10000);
+
+        //todo add tests for DOI, recordID, DOI URL
     });  
 });
 

--- a/test/zenodo.js
+++ b/test/zenodo.js
@@ -37,7 +37,7 @@ describe('API basics', function () {
                 compendium_id = JSON.parse(body).id;
                 done();
             });
-        }).timeout(20000);
+        }).timeout(30000);
 
         it('zenodo record, additional "filename" parameter: should respond with a compendium ID', (done) => {
             let form = {
@@ -225,6 +225,31 @@ describe('API basics', function () {
         it('invalid zenodo_record_id (not a zenodo record): should respond with an error 422', (done) => {
             let form = {
                 zenodo_record_id: 'eigthhundredseventytwo',
+                content_type: 'compendium_v1',
+            };
+
+            let j = request.jar();
+            let ck = request.cookie('connect.sid=' + cookie);
+            j.setCookie(ck, host);
+
+            request({
+                uri: host + '/api/v2/compendium',
+                method: 'POST',
+                jar: j,
+                form: form,
+                timeout: requestLoadingTimeout
+            }, (err, res, body) => {
+                assert.ifError(err);
+                assert.equal(res.statusCode, 422);
+                assert.isUndefined(JSON.parse(body).id, 'returned no id');
+                assert.propertyVal(JSON.parse(body), 'error', 'zenodo_record_id is invalid');
+                done();
+            });
+        }).timeout(10000);
+
+        it('invalid zenodoID in share_url: should respond with an error 422', (done) => {
+            let form = {
+                share_url: 'https://sandbox.zenodo.org/record/asdfasdf',
                 content_type: 'compendium_v1',
             };
 

--- a/test/zenodo.js
+++ b/test/zenodo.js
@@ -1,0 +1,122 @@
+/* eslint-env mocha */
+const assert = require('chai').assert;
+const request = require('request');
+const config = require('../config/config');
+
+const host = 'http://localhost:'  + config.net.port;
+const cookie = 's:C0LIrsxGtHOGHld8Nv2jedjL4evGgEHo.GMsWD5Vveq0vBt7/4rGeoH5Xx7Dd2pgZR9DvhKCyDTY';
+const requestLoadingTimeout = 20000;
+
+
+describe('API basics', function () {
+
+    var compendium_id = '';
+
+    describe('create new compendium based on a zenodo record', () => {
+        it('zenodo record with zip file: should respond with a compendium ID', (done) => {
+            let form = {
+                zenodo_url: 'https://sandbox.zenodo.org/record/69114',
+                filename: 'metatainer.zip',
+                content_type: 'compendium_v1'
+            };
+
+            let j = request.jar();
+            let ck = request.cookie('connect.sid=' + cookie);
+            j.setCookie(ck, host);
+
+            request({
+                uri: host + '/api/v2/compendium',
+                method: 'POST',
+                jar: j,
+                form: form,
+                timeout: requestLoadingTimeout
+            }, (err, res, body) => {
+                assert.ifError(err);
+                assert.equal(res.statusCode, 200);
+                assert.isObject(JSON.parse(body), 'returned JSON');
+                assert.isDefined(JSON.parse(body).id, 'returned id');
+                compendium_id = JSON.parse(body).id;
+                done();
+            });
+        }).timeout(20000);
+
+        it('invalid zenodo URL: should respond with an error 404', (done) => {
+            let form = {
+                zenodo_url: 'htts://sandbox.zenodo.org/record/69114',
+                filename: 'metatainer.zip',
+                content_type: 'compendium_v1',
+            };
+
+            let j = request.jar();
+            let ck = request.cookie('connect.sid=' + cookie);
+            j.setCookie(ck, host);
+
+            request({
+                uri: host + '/api/v2/compendium',
+                method: 'POST',
+                jar: j,
+                form: form,
+                timeout: requestLoadingTimeout
+            }, (err, res, body) => {
+                assert.ifError(err);
+                assert.equal(res.statusCode, 404);
+                assert.isUndefined(JSON.parse(body).id, 'returned no id');
+                assert.propertyVal(JSON.parse(body), 'error', 'zenodo URL is invalid');
+                done();
+            });
+        }).timeout(10000);
+
+        it('invalid host (not a zenodo record): should respond with an error 403', (done) => {
+            let form = {
+                zenodo_url: 'https://sandbox.ODONEZ.org/record/69114',
+                filename: 'metatainer.zip',
+                content_type: 'compendium_v1',
+            };
+
+            let j = request.jar();
+            let ck = request.cookie('connect.sid=' + cookie);
+            j.setCookie(ck, host);
+
+            request({
+                uri: host + '/api/v2/compendium',
+                method: 'POST',
+                jar: j,
+                form: form,
+                timeout: requestLoadingTimeout
+            }, (err, res, body) => {
+                assert.ifError(err);
+                assert.equal(res.statusCode, 403);
+                assert.isUndefined(JSON.parse(body).id, 'returned no id');
+                assert.propertyVal(JSON.parse(body), 'error', 'host is not allowed');
+                done();
+            });
+        }).timeout(10000);
+
+        it('filename not found: should respond with an error 500', (done) => {
+            let form = {
+                zenodo_url: 'https://sandbox.zenodo.org/record/69114',
+                filename: 'not_existing_file.xyz',
+                content_type: 'compendium_v1',
+            };
+
+            let j = request.jar();
+            let ck = request.cookie('connect.sid=' + cookie);
+            j.setCookie(ck, host);
+
+            request({
+                uri: host + '/api/v2/compendium',
+                method: 'POST',
+                jar: j,
+                form: form,
+                timeout: requestLoadingTimeout
+            }, (err, res, body) => {
+                assert.ifError(err);
+                assert.equal(res.statusCode, 500);
+                assert.isUndefined(JSON.parse(body).id, 'returned no id');
+                assert.propertyVal(JSON.parse(body), 'error', '{"error":"download failed: //sandbox.zenodo.org/record/69114/files/not_existing_file.xyz"}');
+                done();
+            });
+        }).timeout(10000);
+    });  
+});
+

--- a/test/zenodo.js
+++ b/test/zenodo.js
@@ -8,7 +8,7 @@ const cookie = 's:C0LIrsxGtHOGHld8Nv2jedjL4evGgEHo.GMsWD5Vveq0vBt7/4rGeoH5Xx7Dd2
 const requestLoadingTimeout = 20000;
 
 
-describe('API basics', function () {
+describe('Zenodo loader basics', function () {
 
     var compendium_id = '';
 


### PR DESCRIPTION
Allows zenodo records to be submitted to the loader

Supports the following input:

- Zenodo record URL
- Zenodo Record ID
- DOI resolving to a zenodo record
- DOI.org link resolving to a zenodo record

Documentation: 
- https://github.com/o2r-project/o2r-web-api/pull/40 
- https://github.com/o2r-project/o2r-web-api/blob/master/docs/compendium/public_share.md