### PR TITLE
fix meta tools version log

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,8 +193,12 @@ function initApp(callback) {
     });
     let versionFile = config.meta.broker.mappings.dir.split('broker/')[0].concat(config.meta.versionFile);
     fs.readFile(versionFile, 'utf8', function (err, data) {
-      debug('meta tools version: %s', data.trim());
-    })
+      if (err) {
+        debug('could not read meta tools version: %s', err);
+      } else {
+        debug('meta tools version: %s', data.trim());
+      }
+    });
 
     /*
      * final startup message

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o2r-loader",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Node.js implementation for loading compendia and workspaces from external repositories for the [o2r web api](http://o2r.info/o2r-web-api).",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- fixes #29
- now logs this if the version file can't be found:

`loader could not read meta tools version: Error: ENOENT: no such file or directory, open '../o2r-meta/version'`